### PR TITLE
fix randomization of auto-assignment

### DIFF
--- a/autoassign.php
+++ b/autoassign.php
@@ -413,7 +413,7 @@ function doAssign() {
 	    if ($pref >= -1000000 && isset($papers[$pid]) && $papers[$pid] > 0
 		&& (!isset($badpairs[$pc]) || noBadPair($pc, $pid, $prefs))) {
 		// make assignment
-		$assignments[] = "$pid,$action," . $pcx->email . $round;
+		$assignments[] = "$pid,$action," . $pcm[$pc]->email . $round;
 		$prefs[$pc][$pid] = -1000001;
 		$papers[$pid]--;
 		$load[$pc]++;


### PR DESCRIPTION
Since $pcx refers to the last value after the randomization loop, this was causing the auto-assigner to assign every paper to the last PC member.

Easy fix once you find it.
