### PR TITLE
Fixes incorrect word count for multi-line comments/responses.

### DIFF
--- a/src/commentview.php
+++ b/src/commentview.php
@@ -323,7 +323,7 @@ class CommentView {
         }
         if ($wordlimit > 0) {
             $buttons[] = "";
-            $wc = preg_match_all("/\\PZ+/u", $ctext, $cm);
+            $wc = preg_match_all("/\\P{Xps}+/u", $ctext, $cm);
             $wct = ($wordlimit < $wc ? plural($wc - $wordlimit, "word") . " over" : plural($wordlimit - $wc, "word") . " left");
             $buttons[] = "<div id='responsewc' class='words"
                 . ($wordlimit < $wc ? " wordsover" :


### PR DESCRIPTION
Fixes #15. (Incorrect word count for multi-line comments)

Details:
- In PHP, \PZ does not include LF, CR, VT, and FF, so instead one should
  use \P{Xps}: http://nikic.github.io/2011/12/10/PCRE-and-newlines.html
