### PR TITLE
fix foldup()

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -588,7 +588,7 @@ function fold(elt, dofold, foldtype) {
 
 function foldup(e, event, opts) {
     var dofold = false, attr, m, foldnum;
-    while (e && e.id.substr(0, 4) != "fold" && !e.getAttribute("hotcrp_fold"))
+    while (e && e.className.substr(0, 4) != "fold" && !e.getAttribute("hotcrp_fold"))
         e = e.parentNode;
     if (!e)
         return true;


### PR DESCRIPTION
Foldable items seem to be identified by class names, not IDs, that begin with 'fold'.  This unbreaks unfolding fields on the administrative settings page; haven't tested other pages that may use foldup().
