### PR TITLE
Add a call out for disabling the capabilities

### DIFF
--- a/src/distoptions.php
+++ b/src/distoptions.php
@@ -204,6 +204,8 @@ $Opt["disablePS"] = true;
 //   disableCsv      Set to true if downloaded information files should be
 //                   tab-separated rather than CSV.
 //   hideManager     If set, PC members are not shown paper managers.
+//   disableCapabilities If set, emails to authors will not have a
+//                   token enabling them to view their papers without logging in.
 
 $Opt["smartScoreCompare"] = true;
 


### PR DESCRIPTION
This feature was not known to us when deploying. After feedback from users, discovering and disabling it took us looking closely at the source code. 

I think there may be some other options that might be worth commenting as well. But this got us where we needed. 

