### PR TITLE
Advanced search: additional options and custom columns

### DIFF
--- a/search.php
+++ b/search.php
@@ -1185,7 +1185,7 @@ function savesearch() {
     // clean display settings
     if ($Conf->session("pldisplay")) {
         $acceptable = array("abstract" => 1, "topics" => 1, "tags" => 1,
-                            "rownum" => 1, "reviewers" => 1,
+                            "rownum" => 1, "reviewers" => 1, "searchopts" => 1,
                             "pcconf" => 1, "lead" => 1, "shepherd" => 1);
         if (!$Conf->subBlindAlways() || $Me->privChair)
             $acceptable["au"] = $acceptable["aufull"] = $acceptable["collab"] = 1;
@@ -1348,6 +1348,11 @@ if ($pl) {
         displayOptionCheckbox("anonau", 1, "Deblinded authors", array("disabled" => (!$pl || !$pl->any->anonau), "indent" => true));
     if ($pl->any->collab)
         displayOptionCheckbox("collab", 1, "Collaborators", array("indent" => true));
+
+    // Search result options
+    global $Opt;
+    if (!empty($Opt["summaryTemplate"]))
+        displayOptionCheckbox("searchopts", 1, "Searched paper options");
 
     // Abstract group
     if ($pl->any->abstract)

--- a/search.php
+++ b/search.php
@@ -78,16 +78,16 @@ if ((isset($_REQUEST["qa"]) || isset($_REQUEST["qo"]) || isset($_REQUEST["qx"]))
                     $query_all .= $delim . $optName . ":<" . _escapeMySqlSearchValue($value);
                     break;
                 case 'IS':
-                    $query_all .= "{$delim}opt:" . $optName . "=" . _escapeMySqlSearchValue($value);
+                    $query_all .= $delim . $optName . ":'" . _escapeMySqlSearchValue($value) . "'";
                     break;
                 case 'STARTS_WITH':
-                    $query_all .= "{$delim}opt:" . $optName . "=" . _escapeMySqlSearchValue($value) . "*";
+                    $query_all .= $delim . $optName . ":'" . _escapeMySqlSearchValue($value) . "%'";
                     break;
                 case 'ENDS_WITH':
                     $query_all .= $delim . $optName . ":'%" . _escapeMySqlSearchValue($value) . "'";
                     break;
                 case 'CONTAINS':
-                    $query_all .= "{$delim}opt:" . $optName . "=*" . _escapeMySqlSearchValue($value) . "*";
+                    $query_all .= $delim . $optName . ":'%" . _escapeMySqlSearchValue($value) . "%'";
                     break;
                 case 'CHECKBOX':
                     $query_all .= $delim . $optName . ":'" . _escapeMySqlSearchValue($value) . "'";

--- a/src/paperlist.php
+++ b/src/paperlist.php
@@ -608,10 +608,10 @@ class PaperList {
             return "id title statusfull";
         case "s":
         case "acc":
-            return "sel id title revtype revstat status authors collab abstract tags tagreports topics reviewers allrevpref pcconf lead shepherd scores formulas";
+            return "sel id title revtype revstat status authors collab abstract tags tagreports topics reviewers allrevpref searchopts pcconf lead shepherd scores formulas";
         case "all":
         case "act":
-            return "sel id title statusfull revtype authors collab abstract tags tagreports topics reviewers allrevpref pcconf lead shepherd scores formulas";
+            return "sel id title statusfull revtype authors collab abstract tags tagreports topics reviewers allrevpref searchopts pcconf lead shepherd scores formulas";
         case "reviewerHome":
             $this->_default_linkto("review");
             return "id title revtype status";
@@ -619,16 +619,16 @@ class PaperList {
         case "lead":
         case "manager":
             $this->_default_linkto("review");
-            return "sel id title revtype revstat status authors collab abstract tags tagreports topics reviewers allrevpref pcconf lead shepherd scores formulas";
+            return "sel id title revtype revstat status authors collab abstract tags tagreports topics reviewers allrevpref searchopts pcconf lead shepherd scores formulas";
         case "rout":
             $this->_default_linkto("review");
-            return "sel id title revtype revstat status authors collab abstract tags tagreports topics reviewers allrevpref pcconf lead shepherd scores formulas";
+            return "sel id title revtype revstat status authors collab abstract tags tagreports topics reviewers allrevpref searchopts pcconf lead shepherd scores formulas";
         case "req":
             $this->_default_linkto("review");
-            return "sel id title revtype revstat status authors collab abstract tags tagreports topics reviewers allrevpref pcconf lead shepherd scores formulas";
+            return "sel id title revtype revstat status authors collab abstract tags tagreports topics reviewers allrevpref searchopts pcconf lead shepherd scores formulas";
         case "reqrevs":
             $this->_default_linkto("review");
-            return "id title revdelegation revsubmitted revstat status authors collab abstract tags tagreports topics reviewers allrevpref pcconf lead shepherd scores formulas";
+            return "id title revdelegation revsubmitted revstat status authors collab abstract tags tagreports topics reviewers allrevpref searchopts pcconf lead shepherd scores formulas";
         case "reviewAssignment":
             $this->_default_linkto("assign");
             return "id title revpref topicscore desirability assrev authors tags topics reviewers allrevtopicpref authorsmatch collabmatch scores formulas";

--- a/src/papersearch.php
+++ b/src/papersearch.php
@@ -1593,7 +1593,7 @@ class PaperSearch {
                     $qo[] = array($o, "=", 0);
                 else if ($o->type == "text") {
                     if (!empty($oval)) {
-                        $xval = " like '%' and Option_X.data like " . str_replace("+", " ", $oval);
+                        $qo[] = array($o, " like '%' and Option_X.data like " . str_replace("+", " ", $oval));
                     }
                 } else if ($o->type === "numeric") {
                     if (preg_match('/\A\s*([-+]?\d+)\s*\z/', $oval, $m))
@@ -2759,7 +2759,7 @@ class PaperSearch {
             if ($t->value[0]->type == "text") {
                 $sqi->add_column($thistab . "_x", "$thistab.value");
                 $t->link = $thistab . "_x";
-                $newValue = str_replace("Option_X.data like '", "Option_$optionNum.data like '", $t->value[1]);
+                $newValue = str_replace("Option_X.data like '", "LOWER(CONVERT(Option_$optionNum.data USING utf8)) like '", $t->value[1]);
                 $q[] = $sqi->columns[$t->link] . $newValue;
             } else {
                 $sqi->add_column($thistab . "_x", "coalesce($thistab.value,0)" . $t->value[1]);


### PR DESCRIPTION
First off, thanks for open-sourcing this and for making such an adaptable system! I'm an undergrad at Northeastern University, and am working on adapting HotCRP for use in admissions for our graduate ECE department. We've been making a few changes that make it easier to look through applications, and perhaps some of these could be useful upstream. PTAL!

This pull request implements a UI for specifying additional options when using Advanced Search, instead of having to use advanced opt: syntax. It also adds a display option that shows the searched values in the search results, and additionally adds support for showing values of options as columns in search results.

Note that some of this code is a bit hacky, as I wasn't too familiar with the entire system. Perhaps the most egregious change is in formula.php; to display values for custom columns, it currently makes a request each time to the DB to get the value. I'm guessing it's possible to do this a lot more cleanly with some changes elsewhere, but it works okay at the moment given our low traffic.

Here's a screenshot showing this functionality:
![screenshot](http://i.imgur.com/Kv2ylqI.png)
