### PR TITLE
Add JSON download of reviews and metadata for Review Quality Collector.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@ extra/d3/d3-hotcrp.min.js
 extra/d3/node_modules
 filestore
 logs
-tmp
 conf/options.php
 Code/options.inc

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ extra/d3/d3-hotcrp.min.js
 extra/d3/node_modules
 filestore
 logs
+tmp
 conf/options.php
 Code/options.inc

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 HotCRP NEWS
 ===========
 
+## Version 2.102 - 10.Apr.2017
+
+* Chairs can export reviews as JSON, along with reviewer and paper metadata and
+  the description of the review form.
+  This will be used by reviewqualitycollector.org to serve HotCRP conferences. 
+  
 ## Version 2.101
 
 * Support delegated reviews that must be “approved” by the delegating PC
@@ -22,7 +28,6 @@ HotCRP NEWS
 * Many bug fixes.
 
 * Thanks for feature requests and bug reports to many users.
-
 
 ## Version 2.100 - 15.Jun.2016
 


### PR DESCRIPTION
Download will include:
- hotcrp_version
- reviews
- papers (metadata only)
- reviewers' contacts (without passwords)
- reviewform

-------------------

Hi Eddie,

we talked about this in, um, October.
The patch has become reasonably neat, small, and non-specialized; other HotCRP users may find it useful, too.
It's taken so long because I wanted to get far enough on the RQC side to be reasonably sure this export actually does the job.
I'd be very happy if you'd deploy this new version 2.102 on hotcrp.com soon, because that is now the event my work will have to wait for.

I thank you for your cooperation so far.

  Lutz