### PR TITLE
Fix 500 when httpAuthLogin is set to a string that isn't valid PHP.

### DIFF
--- a/lib/login.php
+++ b/lib/login.php
@@ -29,7 +29,7 @@ class LoginHelper {
 
     static function check_http_auth() {
         global $Conf, $Me;
-        assert($Conf->opt("httpAuthLogin"));
+        assert($Conf->opt("httpAuthLogin") !== null);
 
         // if user signed out of HTTP authentication, send a reauth request
         if (isset($_SESSION["reauth"])) {


### PR DESCRIPTION
This pull request fixes a 500 caused by PHP's delightful behavior of calling eval() on strings passed to assert(). If the value httpAuthLogin was set to wasn't valid PHP, loading any page would fail with a 500. This patch changes the assert to the presumably intended behavior of just checking that httpAuthLogin is in fact set.