### PR TITLE
A suggestion to make the submission confirmation message clearer (bas…

### DIFF
--- a/src/papertable.php
+++ b/src/papertable.php
@@ -1723,7 +1723,7 @@ class PaperTable {
                 return Ht::xmsg("warning", 'The <a href="' . hoturl("deadlines") . '">submission deadline</a> has passed and the submission will not be reviewed.' . $this->deadlineSettingIs("sub_sub") . $this->_deadline_override_message());
         } else if ($Me->can_update_paper($prow)) {
             if ($this->mode === "edit")
-                return Ht::xmsg("confirm", 'The submission is ready and will be considered for review. You can still make changes if necessary.' . $this->deadlineSettingIs("sub_update"));
+                return Ht::xmsg("confirm", 'The submission is ready and will be considered for review by the committee. You do not need to take any further action. If you wish to make changes please edit your entry and use the Save Submission button.' . $this->deadlineSettingIs("sub_update"));
         } else if ($this->conf->collectFinalPapers()
                    && $prow->outcome > 0
                    && $can_view_decision) {


### PR DESCRIPTION
…ed on actual reported user confusion).

I think this change makes the confirmation message clearer about the state of the submission and the options that remain.