### PR TITLE
Fix issue 112, and allow remote mysql databases in runsql.sh

### DIFF
--- a/lib/dbhelper.sh
+++ b/lib/dbhelper.sh
@@ -165,6 +165,10 @@ set_myargs () {
             myargs="$myargs -p$password"
         fi
     fi
+    if test "$dbhost"
+    then
+	myargs="$myargs -h$dbhost"
+    fi
 }
 
 generate_random_ints () {
@@ -222,6 +226,7 @@ get_dboptions () {
     dbname="`getdbopt dbName 2>/dev/null`"
     dbuser="`getdbopt dbUser 2>/dev/null`"
     dbpass="`getdbopt dbPassword 2>/dev/null`"
+    dbhost="`getdbopt dbHost 2>/dev/null`"
     if test -z "$dbname" -o -z "$dbuser" -o -z "$dbpass"; then
         echo "$1: Can't extract database options from `findoptions`!" 1>&2
         if test "`getdbopt multiconference 2>/dev/null`" '!=' "''"; then

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -9,7 +9,7 @@ CREATE TABLE `ActionLog` (
   `destContactId` int(11) NOT NULL DEFAULT '0',
   `paperId` int(11) DEFAULT NULL,
   `time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `ipaddr` varbinary(32) DEFAULT NULL,
+  `ipaddr` varbinary(39) DEFAULT NULL,
   `action` varbinary(4096) NOT NULL,
   PRIMARY KEY (`logId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/src/updateschema.php
+++ b/src/updateschema.php
@@ -1290,6 +1290,10 @@ set ordinal=(t.maxOrdinal+1) where commentId=$row[1]");
         && $conf->ql("alter table ContactInfo change `voicePhoneNumber` `voicePhoneNumber` varbinary(256) DEFAULT NULL"))
         $conf->update_schema_version(180);
 
+    if ($conf->sversion == 180
+        && $conf->ql("alter table ActionLog change `ipaddr` `ipaddr` varbinary(39) DEFAULT NULL"))
+        $conf->update_schema_version(181);
+
     $conf->ql("delete from Settings where name='__schema_lock'");
     Conf::$g = $old_conf_g;
 }


### PR DESCRIPTION
Increase the size of the ipaddr field in ActionLog to 39characters.
Use the dbHost config variable in runsql.sh.