### PR TITLE
make non-hotcrp.com comments and reviews look less horrible

### DIFF
--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -2839,6 +2839,7 @@ body#offline .revcard {
 	margin-bottom: 0;
 }
 .revtext, .cmttext {
+	white-space: pre-wrap;
 	position: relative;
 }
 .preview {


### PR DESCRIPTION
Reviews outside of hotcrp.com don't get markdown'd, and multi-paragraph comments end up turning into gnarly walls of text due to html's default text rendering. This css class fixes that issue on comments and reviews. One issue is that when composed with `marked` multiple successive line breaks are preserved, so anyone putting excessive space between paragraphs will see those rather than having them rendered as a single line break.