### PR TITLE
docker-compose environment for hotcrp

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,39 @@ emailReplyTo, and docstore.
 4. Each conference needs its own database. Create one using the
    `lib/createdb.sh` script (the `-c CONFIGFILE` option will be useful).
 
+
+Docker
+-------
+
+Start hotcrp in docker-environment
+
+1) Start docker compse
+
+`docker-compose up`
+
+2) Only on first run: Initialize database
+
+```
+# attach to mysql docker 
+docker exec -i -t hotcrp-database /bin/bash
+
+# create database
+# select no when asked for database creation, only fill database with scheme!!!!!
+# ok -> hotcrp -> n -> Y
+./lib/createdb.sh --dbuser=hotcrp,hotcrppwd --user=root --password=rootpwd
+```
+
+3) control conf/options.php may add:
+
+```$xslt
+$Opt["dsn"] = "mysql://hotcrp:hotcrppwd@hotcrp-mysql:3306/hotcrp";
+```
+
+5) Check connection 
+
+`http://localhost:9000` 
+
+
 License
 -------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+###############################################################################
+#                          Generated on phpdocker.io                          #
+###############################################################################
+version: "3.1"
+services:
+
+    mysql:
+      image: mysql:5.7
+      command: --max_allowed_packet=104857600      # Set max_allowed_packet to 256M (or any other value)
+      container_name: hotcrp-database
+      working_dir: /application
+      volumes:
+        - .:/application
+      environment:
+        - MYSQL_ROOT_PASSWORD=rootpwd
+        - MYSQL_DATABASE=hotcrp
+        - MYSQL_USER=hotcrp
+        - MYSQL_PASSWORD=hotcrppwd
+      ports:
+        - "9002:3306"
+
+    webserver:
+      image: nginx:alpine
+      container_name: hotcrp-web
+      working_dir: /application
+      volumes:
+          - .:/application
+          - ./phpdocker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+      ports:
+       - "9000:80"
+       - "9443:443"
+
+    php-fpm:
+      build: phpdocker/php-fpm
+      container_name: hotcrp-php
+      working_dir: /application
+      links:
+        - mysql
+      ports:
+        - "9001:9000"
+      volumes:
+        - .:/application
+        - ./phpdocker/php-fpm/php-ini-overrides.ini:/etc/php/7.2/fpm/conf.d/99-overrides.ini
+
+    phpmyadmin:
+      image: phpmyadmin/phpmyadmin
+      container_name: hotcrp-database-admin
+      working_dir: /application
+      links:
+        - mysql
+      environment:
+        - PMA_HOST=hotcrp-database
+        - PMA_PORT=3306
+        - PMA_USER=root
+        - PMA_PASSWORD=rootpwd
+      ports:
+        - "9005:80"

--- a/phpdocker/nginx/nginx.conf
+++ b/phpdocker/nginx/nginx.conf
@@ -1,0 +1,23 @@
+server {
+    listen 80 default;
+    client_max_body_size 108M;
+    access_log /var/log/nginx/application.access.log;
+
+    root /application;
+    index index.php;
+
+    if (!-e $request_filename) {
+        rewrite ^.*$ /index.php last;
+    }
+
+    location ~ \.php$ {
+        fastcgi_pass php-fpm:9000;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PHP_VALUE "error_log=/var/log/nginx/application_php_errors.log";
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
+        include fastcgi_params;
+    }
+    
+}

--- a/phpdocker/php-fpm/Dockerfile
+++ b/phpdocker/php-fpm/Dockerfile
@@ -1,0 +1,17 @@
+FROM phpdockerio/php72-fpm:latest
+WORKDIR "/application"
+
+# Install selected extensions and other stuff
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install  php7.2-mysql php-redis php-mongodb \
+    && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+
+# Install git
+RUN apt-get update \
+    && apt-get -y install git \
+    && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+
+# Install git
+RUN apt-get update \
+    && apt-get -y install curl msmtp ca-certificates \
+    && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*

--- a/phpdocker/php-fpm/php-ini-overrides.ini
+++ b/phpdocker/php-fpm/php-ini-overrides.ini
@@ -1,0 +1,4 @@
+upload_max_filesize = 100M
+post_max_size = 108M
+max_input_vars = 4096
+session.gc_maxlifetime = 86400


### PR DESCRIPTION
Allows to run hotcrp within an docker environment. As docker basis phpdocker.io is used. 


Start hotcrp in docker-environment

1) Start docker compse

`docker-compose up`

2) Only on first run: Initialize database

```
# attach to mysql docker 
docker exec -i -t hotcrp-database /bin/bash

# create database
# select no when asked for database creation, only fill database with scheme!!!!!
# ok -> hotcrp -> n -> Y
./lib/createdb.sh --dbuser=hotcrp,hotcrppwd --user=root --password=rootpwd
```

3) control conf/options.php may add:

```$xslt
$Opt["dsn"] = "mysql://hotcrp:hotcrppwd@hotcrp-mysql:3306/hotcrp";
```

5) Check connection 

`http://localhost:9000` 
