### PR TITLE
Adding support for PaperOptions::required on Settings page

### DIFF
--- a/etc/settinggroups.json
+++ b/etc/settinggroups.json
@@ -154,6 +154,10 @@
         "render_option_property_callback": "Options_SettingRenderer::render_presence_property"
     },
     {
+        "name": "options/properties/required", "position": 31,
+        "render_option_property_callback": "Options_SettingRenderer::render_required_property"
+    },
+    {
         "name": "options/properties/visibility", "position": 40,
         "render_option_property_callback": "Options_SettingRenderer::render_visibility_property"
     },

--- a/src/settings/s_options.php
+++ b/src/settings/s_options.php
@@ -72,6 +72,14 @@ class Options_SettingRenderer {
             . $sv->render_messages_at("optec_$xpos")
             . "</span></div>";
     }
+    static function render_required_property(SettingValues $sv, PaperOption $o, $xpos, $self, $gj) {
+        $self->add_option_class("fold9" . ($o->required ? "o" : "c"));
+        return '<div class="' . $sv->control_class("optreq_$xpos", "entryi short fx9")
+            . '">' . $sv->label("optreq_$xpos", "Required")
+            . Ht::select("optreq_$xpos", ["" => "No", "1" => "Yes"], $o->required ? "1" : "", ["id" => "optreq_$xpos"])
+            . $sv->render_messages_at("optreq_$xpos")
+            . "</div>";
+    }
     static function render_visibility_property(SettingValues $sv, PaperOption $o, $xpos, $self, $gj) {
         $self->add_option_class("fold6" . ($o->visibility === "rev" ? "c" : "o"));
         return '<div class="' . $sv->control_class("optp_$xpos", "entryi short fx6")


### PR DESCRIPTION
Admins can now mark a custom submission field as required when building a form. There is already support for enforcing required fields on the backend.