### PR TITLE
send email even when creating normal user

### DIFF
--- a/src/userstatus.php
+++ b/src/userstatus.php
@@ -992,6 +992,8 @@ class UserStatus extends MessageSet {
             } else if (($roles & Contact::ROLE_ADMIN)
                        && !($eff_old_roles & Contact::ROLE_ADMIN)) {
                 $user->send_mail("@newaccount.admin");
+            } else {
+                $user->send_mail("@newaccount");
             }
         }
 

--- a/test/emails.txt
+++ b/test/emails.txt
@@ -77,7 +77,30 @@ concerns.
 
 - Testconf I Submissions
 ******** create-kohler@seas.harvard.edu
+To: Eddie Kohler <kohler@seas.harvard.edu>
+Subject: [Testconf I] New account
 
+Greetings,
+
+An account has been created for you at the Test Conference I (Testconf I) submission site.
+
+        Site: http://hotcrp.lcdf.org/test/
+       Email: kohler@seas.harvard.edu
+
+You will need a password to sign in. Use this link to set one up:
+
+http://hotcrp.lcdf.org/test/resetpassword/{{}}
+
+Should the link expire, obtain a new link using "Forgot my password".
+
+If you already have an account under a different email address, you may
+merge this new account into that one. Go to your profile page and select
+"Merge with another account".
+
+Contact Eddie Kohler <ekohler@hotcrp.lcdf.org> with any questions or
+concerns.
+
+- Testconf I Submissions
 ******** create-varghese@ccrc.wustl.edu
 To: George Varghese <varghese@ccrc.wustl.edu>
 Subject: [Testconf I] Welcome to the program committee
@@ -417,7 +440,30 @@ concerns.
 
 - Testconf I Submissions
 ******** create-van@ee.lbl.gov
+To: Van Jacobson <van@ee.lbl.gov>
+Subject: [Testconf I] New account
 
+Greetings,
+
+An account has been created for you at the Test Conference I (Testconf I) submission site.
+
+        Site: http://hotcrp.lcdf.org/test/
+       Email: van@ee.lbl.gov
+
+You will need a password to sign in. Use this link to set one up:
+
+http://hotcrp.lcdf.org/test/resetpassword/{{}}
+
+Should the link expire, obtain a new link using "Forgot my password".
+
+If you already have an account under a different email address, you may
+merge this new account into that one. Go to your profile page and select
+"Merge with another account".
+
+Contact Eddie Kohler <ekohler@hotcrp.lcdf.org> with any questions or
+concerns.
+
+- Testconf I Submissions
 ******** create-ojuelegba@gmail.com
 To: Wilma Ojuelegba <ojuelegba@gmail.com>
 Subject: [Testconf I] Welcome to the program committee

--- a/test/emails.txt
+++ b/test/emails.txt
@@ -82,7 +82,8 @@ Subject: [Testconf I] New account
 
 Greetings,
 
-An account has been created for you at the Test Conference I (Testconf I) submission site.
+An account has been created for you at the Test Conference I (Testconf
+I) submission site.
 
         Site: http://hotcrp.lcdf.org/test/
        Email: kohler@seas.harvard.edu
@@ -445,7 +446,8 @@ Subject: [Testconf I] New account
 
 Greetings,
 
-An account has been created for you at the Test Conference I (Testconf I) submission site.
+An account has been created for you at the Test Conference I (Testconf
+I) submission site.
 
         Site: http://hotcrp.lcdf.org/test/
        Email: van@ee.lbl.gov


### PR DESCRIPTION
When the admin creates a normal user (not Chair and not PC), it was displayed that an email has been sent, but that was not the case.

I just added a line to make sure an email is always sent when a user is created by an admin.