### PR TITLE
Fix assert with string (causing a warning in PHP 7.2+ and an error in PHP 8)

### DIFF
--- a/lib/dbl.php
+++ b/lib/dbl.php
@@ -125,7 +125,7 @@ class Dbl_ConnectionParams {
 
     /** @return ?\mysqli */
     function connect() {
-        assert($this->name);
+        assert(!empty($this->name));
         if ($this->socket) {
             $dblink = new mysqli($this->host, $this->user, $this->password, "", $this->port, $this->socket);
         } else if ($this->port !== null) {


### PR DESCRIPTION
As the doc of php says: "Using string as the assertion is DEPRECATED as of PHP 7.2.0 and REMOVED as of PHP 8.0.0." ([https://www.php.net/manual/en/function.assert.php](https://www.php.net/manual/en/function.assert.php))

I think you wanted to check that the string is not empty.

PS: thanks for the work on this awesome project :)