### PR TITLE
Adds database SSL/TLS options support

### DIFF
--- a/etc/distoptions.php
+++ b/etc/distoptions.php
@@ -202,13 +202,30 @@ $Opt["smartScoreCompare"] = true;
 //                   HotCRP will *not* redirect HTTP connections that
 //                   originate from localhost.
 
-
-// EXTERNAL SOFTWARE CONFIGURATION
+// EXTENDED DATABASE OPTIONS
 //
 //   dbHost          Database host. Defaults to localhost.
+//   dbSsl           If true, other options prefixed with 'dbSsl' will apply.
+//                   Defaults to false.
+//   dbSslKey        The location of the key for the SSL certficate for mTLS
+//                   authentication. Defaults to null.
+//   dbSslCert       The location of the SSL certificate for mTLS
+//                   authentication. Defaults to null.
+//   dbSslCa         The location of the CA certificate to validate the server
+//                   certificate against. Defaults to null.
+//   dbSslCapath     The location of the folder that contains CA certificates
+//                   to validate the server certificate against.
+//                   Defaults to null.
+//   dbSslCipher     A list of allowable ciphers to use for SSL encryption.
+//                   Defaults to null, i.e. system defaults apply.
+//   dbSslVerify     If true, verifies the server's certificate.
+//                   Defaults to true.
 //   dsn             Database configuration string in the format
 //                   "mysql://DBUSER:DBPASSWORD@DBHOST/DBNAME".
 //                   The default is derived from $Opt["dbName"], etc.
+
+// EXTERNAL SOFTWARE CONFIGURATION
+//
 //   memoryLimit     Maximum amount of memory a PHP script can use. Defaults
 //                   to 128MB.
 //   pdftohtml       Pathname to pdftohtml executable (used only by the "banal"

--- a/lib/dbl.php
+++ b/lib/dbl.php
@@ -118,6 +118,21 @@ class Dbl_ConnectionParams {
     /** @var ?string */
     public $name;
 
+    /** @var ?boolean */
+    public $ssl;
+    /** @var ?string */
+    public $ssl_key;
+    /** @var ?string */
+    public $ssl_cert;
+    /** @var ?string */
+    public $ssl_ca;
+    /** @var ?string */
+    public $ssl_capath;
+    /** @var ?string */
+    public $ssl_cipher;
+    /** @var ?bool */
+    public $ssl_verify = true;
+
     /** @return string */
     function sanitized_dsn() {
         $t = "mysql://";
@@ -129,28 +144,43 @@ class Dbl_ConnectionParams {
 
     /** @return ?\mysqli */
     function connect() {
-        assert(($this->name ?? "") !== "");
-        if ($this->socket) {
-            $dblink = new mysqli($this->host, $this->user, $this->password, "", $this->port, $this->socket);
-        } else if ($this->port !== null) {
-            $dblink = new mysqli($this->host, $this->user, $this->password, "", $this->port);
-        } else {
-            $dblink = new mysqli($this->host, $this->user, $this->password);
-        }
+	assert(($this->name ?? "") !== "");
+
+	$dblink = new mysqli();
+	$client_flags = 0;
+
+	if ($this->ssl) {
+	    $client_flags += MYSQLI_CLIENT_SSL;
+	    if ($this->ssl_verify) {
+                defined('MYSQLI_OPT_SSL_VERIFY_SERVER_CERT') && $dblink->options(MYSQLI_OPT_SSL_VERIFY_SERVER_CERT, true);
+	    } else {
+                defined('MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT') && $client_flags += MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT;
+            }
+            $dblink->ssl_set($this->ssl_key, $this->ssl_cert, $this->ssl_ca, $this->ssl_capath, $this->ssl_cipher);
+	}
+
+	$dblink->real_connect(
+	    $this->host,
+	    $this->user,
+	    $this->password,
+	    $this->name,
+	    $this->port,
+	    $this->socket,
+	    $client_flags
+	);
+
         if ($dblink->connect_errno || mysqli_connect_errno()) {
             return null;
-        } else if (!$dblink->select_db($this->name)) {
-            $dblink->close();
-            return null;
-        } else {
-            // We send binary strings to MySQL, so we don't want warnings
-            // about non-UTF-8 data
-            $dblink->set_charset("binary");
-            // The necessity of the following line is explosively terrible
-            // (the default is 1024/!?))(U#*@$%&!U
-            $dblink->query("set group_concat_max_len=4294967295");
-            return $dblink;
-        }
+	}
+
+        // We send binary strings to MySQL, so we don't want warnings
+        // about non-UTF-8 data
+        $dblink->set_charset("binary");
+        // The necessity of the following line is explosively terrible
+        // (the default is 1024/!?))(U#*@$%&!U
+	$dblink->query("set group_concat_max_len=4294967295");
+
+        return $dblink;
     }
 }
 
@@ -248,7 +278,31 @@ class Dbl {
         }
         $cp->host = $cp->host ?? ini_get("mysqli.default_host");
         $cp->user = $cp->user ?? ini_get("mysqli.default_user");
-        $cp->password = $cp->password ?? ini_get("mysqli.default_pw");
+	$cp->password = $cp->password ?? ini_get("mysqli.default_pw");
+
+	if (isset($opt["dbSsl"]) && is_bool($opt["dbSsl"]) && $opt["dbSsl"]) {
+	    $cp->ssl = true;
+            
+	    if (isset($opt["dbSslKey"]) && is_string($opt["dbSslKey"])) {
+                $cp->ssl_key = $opt["dbSslKey"];
+	    }
+            if (isset($opt["dbSslCert"]) && is_string($opt["dbSslCert"])) {
+                $cp->ssl_cert = $opt["dbSslCert"];
+	    }
+            if (isset($opt["dbSslCa"]) && is_string($opt["dbSslCa"])) {
+                $cp->ssl_ca = $opt["dbSslCa"];
+	    }
+            if (isset($opt["dbSslCapath"]) && is_string($opt["dbSslCapath"])) {
+                $cp->ssl_capath = $opt["dbSslCapath"];
+	    }
+            if (isset($opt["dbSslCipher"]) && is_string($opt["dbSslCipher"])) {
+                $cp->ssl_cipher = $opt["dbSslCipher"];
+	    }
+            if (isset($opt["dbSslVerify"]) && is_bool($opt["dbSslVerify"])) {
+                $cp->ssl_verify = $opt["dbSslVerify"];
+	    }
+	}
+
         return $cp;
     }
 


### PR DESCRIPTION
This pull requests adds new options to configure SSL/TLS secured database connections:
  - dbSslCaCert
  - dbSslCert
  - dbSslKey
  - dbSslVerifyServerCert

These options are passed through to mysqli. The database connection creation was adjusted to cater these changes.

We internally plan to require encrypted database connections (by the [require_secure_transport](https://mariadb.com/kb/en/server-system-variables/#require_secure_transport) option of MariaDB) and hence have developed a patch to allow HotCrp to communicate over an encrypted database connection. We internally did some (quick) testing against:
- An external MariaDB database, specified via URL (default port) without SSL/TLS configured
- An external MariaDB database, specified via URL (default port) with just the server authentication configured
- An external MariaDB database, specified via URL (default port) with [server and client authentication](https://mariadb.com/kb/en/securing-connections-for-client-and-server/#enabling-two-way-tls-for-mariadb-clients) configured