### PR TITLE
Fix creating docstore

### DIFF
--- a/lib/filer.php
+++ b/lib/filer.php
@@ -466,6 +466,9 @@ class Filer {
         while (str_ends_with($container, "/")) {
             $container = substr($container, 0, strlen($container) - 1);
         }
+        while (str_ends_with($fdir, "/")) {
+            $container = substr($fdir, 0, strlen($fdir) - 1);
+        }
         if (!is_dir($container)) {
             if (strlen($container) < strlen($fdir)
                 || !($parent = self::_make_fpath_parents($fdir, $container))


### PR DESCRIPTION
If `docstore` is set to true in the options.php, hotcrp fails to create the `docs` directory because in `_make_fpath_parents` `$container` will be `<root>/docs` and `$fdir` is `<root>/docs/`. Therefore, the check in line 470 `strlen($container) < strlen($fdir)` will be true and the function returns without creating the directory.

This fix removes trailing `/` from `$fdir` as it is done for `$container` and solves this problem.