### PR TITLE
Feature request: Add settings option to always hide reviewer identity from PC members

### DIFF
--- a/src/settings/s_review.php
+++ b/src/settings/s_review.php
@@ -217,7 +217,8 @@ class Review_SettingParser extends SettingParser {
         $sv->print_radio_table("review_identity_visibility_pc", [
                 Conf::VIEWREV_ALWAYS => "Yes",
                 Conf::VIEWREV_IFASSIGNED => "Only if assigned a review for the same submission",
-                Conf::VIEWREV_AFTERREVIEW => "Only after completing a review for the same submission"
+                Conf::VIEWREV_AFTERREVIEW => "Only after completing a review for the same submission",
+                Conf::VIEWREV_NEVER => "No",
             ],
             'Can non-conflicted PC members see <strong>reviewer names</strong>?',
             ["after" => $hint]);


### PR DESCRIPTION
For the setting `review_identity_visiblity_pc`, the option "never" was already included in `settinginfo.json`, however this option is not selectable in settings. I changed this in my commit.