### PR TITLE
Allow `%` hostname in grant-hosts and names including `_`

### DIFF
--- a/lib/createdb.sh
+++ b/lib/createdb.sh
@@ -50,7 +50,7 @@ set_dbuserpass () {
 }
 
 add_granthost () {
-    if expr "$1" : '[-a-zA-Z0-9.*][-a-zA-Z0-9.*]*$' >/dev/null; then
+    if [ "$1" = "%" ] || expr "$1" : '[a-zA-Z][a-zA-Z0-9._-]*[a-zA-Z0-9]$' >/dev/null; then
         granthosts="$granthosts $1"
     else
         echo "Expected --grant-host=HOSTNAME" 1>&2


### PR DESCRIPTION
closes #390

As the title says.
With this, hostnames cannot start with a number or special character and cannot end with a special character. In this form, single letter hostnames (apart from `%`), will not work.

Depending on your preference, a simpler expression, which allows single letter hostnames but also some invalid ones, would also work.

Previously, hostnames including `*` were also accepted, please let me know if that is intentional.