### PR TITLE
Add reactions feature

### DIFF
--- a/etc/apifunctions.json
+++ b/etc/apifunctions.json
@@ -75,6 +75,18 @@
         "response_deprecated": "cmt"
     },
     {
+        "name": "reaction", "get": true, "paper": true,
+        "function": "Reaction_API::run",
+        "parameters": "c ?emoji",
+        "response": "reactions"
+    },
+    {
+        "name": "reaction", "post": true, "paper": true,
+        "function": "Reaction_API::run", 
+        "parameters": "c emoji",
+        "response": "action reactions"
+    },
+    {
         "name": "cspreport", "post": true, "check_token": false,
         "function": "Error_API::cspreport"
     },

--- a/etc/settingdescriptions.md
+++ b/etc/settingdescriptions.md
@@ -86,3 +86,28 @@ formula “avg(OveMer)” would set the tag’s value to the relevant paper’s
 average overall merit score. If the formula evaluates to null for a paper,
 then the tag for that paper is removed. If `value` is an empty string, 0 is
 used.
+
+
+# comment_reactions
+
+> Controls whether users can add emoji reactions to comments
+
+When enabled (the default), users can add emoji reactions to comments they can view. 
+Reactions are shown as small emoji buttons below each comment. Users can click to 
+add or remove their reaction.
+
+
+# comment_reaction_emojis
+
+> Specifies which emojis are available for comment reactions
+
+A comma-separated list of emoji codes that will appear as quick-reaction buttons
+when users click to add a reaction to a comment. Users can always search for
+and add any emoji from the full emoji list, but these are the ones shown by
+default.
+
+The default list includes: `thumbs_up`, `thumbs_down`, `heart`, `laugh`, 
+`confused`, `hooray`, `rocket`, `eyes`.
+
+Emoji codes must match those defined in the system's emoji database 
+(`scripts/emojicodes.json`).

--- a/etc/settingdescriptions.md
+++ b/etc/settingdescriptions.md
@@ -92,7 +92,7 @@ used.
 
 > Controls whether users can add emoji reactions to comments
 
-When enabled (the default), users can add emoji reactions to comments they can view. 
+When enabled, users can add emoji reactions to comments they can view. 
 Reactions are shown as small emoji buttons below each comment. Users can click to 
 add or remove their reaction.
 
@@ -106,8 +106,8 @@ when users click to add a reaction to a comment. Users can always search for
 and add any emoji from the full emoji list, but these are the ones shown by
 default.
 
-The default list includes: `thumbs_up`, `thumbs_down`, `heart`, `laugh`, 
-`confused`, `hooray`, `rocket`, `eyes`.
+The default list includes: `thumbsup`, `thumbsdown`, `heart`, `joy`, 
+`confused`, `tada`, `rocket`, `eyes`.
 
 Emoji codes must match those defined in the system's emoji database 
-(`scripts/emojicodes.json`).
+(available at `scripts/emojicodes.json`).

--- a/etc/settinginfo.json
+++ b/etc/settinginfo.json
@@ -47,6 +47,19 @@
         "type": "checkbox", "initial_value": 1, "json": "in",
         "tags": "comment visibility"
     },
+    {
+        "name": "comment_reactions", "storage": "cmt_reactions",
+        "title": "Allow comment reactions",
+        "type": "checkbox", "default_value": 1,
+        "tags": "comment"
+    },
+    {
+        "name": "comment_reaction_emojis", "storage": "opt.commentReactionEmojis",
+        "title": "Comment reaction emoji list",
+        "type": "string", "subtype": "list",
+        "default_value": "thumbs_up,thumbs_down,heart,laugh,confused,hooray,rocket,eyes",
+        "tags": "comment"
+    },
 
     {
         "name": "decisions", "hashid": "decision-types", "internal": true

--- a/etc/settinginfo.json
+++ b/etc/settinginfo.json
@@ -50,14 +50,14 @@
     {
         "name": "comment_reactions", "storage": "cmt_reactions",
         "title": "Allow comment reactions",
-        "type": "checkbox", "default_value": 1,
+        "type": "checkbox", "default_value": 0,
         "tags": "comment"
     },
     {
         "name": "comment_reaction_emojis", "storage": "opt.commentReactionEmojis",
         "title": "Comment reaction emoji list",
         "type": "string", "subtype": "list",
-        "default_value": "thumbs_up,thumbs_down,heart,laugh,confused,hooray,rocket,eyes",
+        "default_value": "+1,thumbsdown,heart,joy,confused,tada,rocket,eyes",
         "tags": "comment"
     },
 

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -5,6 +5,17 @@
 var siteinfo, hotcrp;
 hotcrp = {};
 hotcrp.text = {};
+hotcrp.reactions = {enabled: false, quick: []};
+hotcrp.set_reaction_config = function (cfg) {
+    cfg || (cfg = {});
+    const quick = Array.isArray(cfg.quick) ? cfg.quick.filter(function (x) {
+        return typeof x === "string" && x.length > 0;
+    }) : [];
+    hotcrp.reactions = {
+        enabled: !!cfg.enabled,
+        quick: quick
+    };
+};
 
 function $$(id) {
     return document.getElementById(id);
@@ -7957,27 +7968,48 @@ handle_ui.on("js-overlong-expand", function () {
 
 // Reaction-related functions
 function cmt_render_reactions(cj, celt) {
+    if (!celt) {
+        return;
+    }
     const reactions_container = celt.querySelector(".comment-reactions");
     if (reactions_container) {
         reactions_container.remove();
     }
-    
+
+    if (!hotcrp.reactions.enabled) {
+        return;
+    }
+
+    const reactions_data = cj && cj.reactions ? cj.reactions : {};
+    const entries = Object.entries(reactions_data);
+    const can_react = !!(cj && cj.can_react);
+
+    if (entries.length === 0 && !can_react) {
+        return;
+    }
+
     const reactions_div = $e("div", "comment-reactions");
-    
+
     // Render existing reactions
-    for (const [emoji, data] of Object.entries(cj.reactions)) {
-        const reaction_span = create_reaction_element(emoji, data, cj.cid);
+    for (const [emoji, data] of entries) {
+        const reaction_span = create_reaction_element(emoji, data, cj ? cj.cid : undefined);
         reactions_div.appendChild(reaction_span);
     }
-    
+
     // Add reaction picker button
-    const picker_btn = $e("button", {
-        type: "button",
-        class: "reaction-picker-btn btn-licon need-tooltip ui",
-        "data-comment-id": cj.cid,
-        title: "Add reaction"
-    }, "+");
-    reactions_div.appendChild(picker_btn);
+    if (can_react) {
+        const picker_btn = $e("button", {
+            type: "button",
+            class: "reaction-picker-btn btn-licon need-tooltip ui",
+            "data-comment-id": cj ? cj.cid : "",
+            title: "Add reaction"
+        });
+        picker_btn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-emoji-smile" viewBox="0 0 16 16">
+  <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/>
+  <path d="M4.285 9.567a.5.5 0 0 1 .683.183A3.5 3.5 0 0 0 8 11.5a3.5 3.5 0 0 0 3.032-1.75.5.5 0 1 1 .866.5A4.5 4.5 0 0 1 8 12.5a4.5 4.5 0 0 1-3.898-2.25.5.5 0 0 1 .183-.683M7 6.5C7 7.328 6.552 8 6 8s-1-.672-1-1.5S5.448 5 6 5s1 .672 1 1.5m4 0c0 .828-.448 1.5-1 1.5s-1-.672-1-1.5S9.448 5 10 5s1 .672 1 1.5"/>
+</svg>`;
+        reactions_div.appendChild(picker_btn);
+    }
 
     // Insert reactions after comment text
     const cmttext = celt.querySelector(".cmttext");
@@ -8018,6 +8050,9 @@ function create_reaction_element(emoji, data, commentId) {
 }
 
 function show_emoji_picker(button) {
+    if (!hotcrp.reactions.enabled || !button) {
+        return;
+    }
     // Remove any existing picker
     const existing_picker = document.querySelector(".emoji-picker");
     if (existing_picker) {
@@ -8044,10 +8079,13 @@ function show_emoji_picker(button) {
 
 function create_emoji_picker(emoji_data, button) {
     const picker = $e("div", "emoji-picker");
-    const common_emojis = ["+1", "thumbsdown", "heart", "100", "laugh", "tada", "rocket", "pray"];
-    
+    const fallback_quick = ["thumbsup", "thumbsdown", "heart", "joy", "confused", "tada", "rocket", "eyes"];
+    const common_emojis = (hotcrp.reactions.quick && hotcrp.reactions.quick.length)
+        ? hotcrp.reactions.quick
+        : fallback_quick;
+
     const common_section = $e("div", "emoji-section");
-    
+
     // Add common emojis
     const common_grid = $e("div", "emoji-grid");
     for (const emoji_name of common_emojis) {
@@ -8159,6 +8197,9 @@ function position_emoji_picker(picker, button) {
 }
 
 function toggle_reaction(commentId, emoji, celt) {
+    if (!hotcrp.reactions.enabled) {
+        return;
+    }
     const url = hoturl("=api/reaction", {p: siteinfo.paperid, c: commentId});
     const data = {emoji: emoji};
     
@@ -8184,10 +8225,16 @@ function toggle_reaction(commentId, emoji, celt) {
 // Event handlers
 handle_ui.on("reaction-picker-btn", function(evt) {
     evt.preventDefault();
+    if (!hotcrp.reactions.enabled) {
+        return;
+    }
     show_emoji_picker(this);
 });
 
 handle_ui.on("reaction-item", function(evt) {
+    if (!hotcrp.reactions.enabled) {
+        return;
+    }
     const emoji = this.getAttribute("data-emoji");
     const commentId = this.getAttribute("data-comment-id");
     const celt = this.closest(".cmtid");

--- a/src/api/api_reaction.php
+++ b/src/api/api_reaction.php
@@ -1,0 +1,134 @@
+<?php
+// api_reaction.php -- HotCRP reaction API call
+// Copyright (c) 2008-2025 Eddie Kohler; see LICENSE.
+
+class Reaction_API {
+    /** @var Conf */
+    private $conf;
+    /** @var Contact */
+    private $user;
+    /** @var PaperInfo */
+    private $prow;
+    /** @var CommentInfo */
+    private $comment;
+    /** @var MessageSet */
+    private $ms;
+
+    function __construct(Contact $user, PaperInfo $prow, CommentInfo $comment) {
+        $this->conf = $user->conf;
+        $this->user = $user;
+        $this->prow = $prow;
+        $this->comment = $comment;
+        $this->ms = new MessageSet;
+    }
+
+    /** @return JsonResult */
+    private function run_qreq(Qrequest $qreq) {
+        // Check if reactions are enabled
+        if (!$this->conf->setting("cmt_reactions", 1)) {
+            return JsonResult::make_error(404, "<0>Comment reactions are disabled");
+        }
+
+        // Check if user can view the comment
+        if (!$this->user->can_view_comment($this->prow, $this->comment, true)) {
+            return JsonResult::make_error(403, "<0>You aren't allowed to view that comment");
+        }
+
+        // Check if user can react (same permission as viewing comment)
+        if (!$this->user->can_view_comment($this->prow, $this->comment)) {
+            return JsonResult::make_error(403, "<0>You aren't allowed to react to that comment");
+        }
+
+        $emoji = trim($qreq->emoji ?? "");
+        if (!$emoji) {
+            return JsonResult::make_parameter_error("emoji");
+        }
+
+        // Validate emoji (check against emoji list)
+        if (!$this->is_valid_emoji($emoji)) {
+            return JsonResult::make_error(400, "<0>Invalid emoji");
+        }
+
+        if ($qreq->is_post()) {
+            return $this->handle_post($emoji);
+        } else {
+            return $this->handle_get();
+        }
+    }
+
+    /** @param string $emoji
+     * @return bool */
+    private function is_valid_emoji($emoji) {
+        static $valid_emojis = null;
+        if ($valid_emojis === null) {
+            $emoji_file = SiteLoader::find("scripts/emojicodes.json");
+            if ($emoji_file) {
+                $emoji_data = json_decode(file_get_contents($emoji_file), true);
+                $valid_emojis = array_keys($emoji_data["emoji"] ?? []);
+            } else {
+                $valid_emojis = [];
+            }
+        }
+        return in_array($emoji, $valid_emojis);
+    }
+
+    /** @param string $emoji
+     * @return JsonResult */
+    private function handle_post($emoji) {
+        // Check if reaction already exists
+        $existing_reaction = $this->comment->find_reaction($this->user, $emoji);
+        
+        if ($existing_reaction) {
+            // Remove existing reaction (toggle off)
+            $success = $this->comment->remove_reaction($this->user, $emoji);
+            if ($success) {
+                $this->ms->success("<0>Reaction removed");
+                $action = "removed";
+            } else {
+                return JsonResult::make_error(500, "<0>Failed to remove reaction");
+            }
+        } else {
+            // Add new reaction
+            $reaction = $this->comment->add_reaction($this->user, $emoji);
+            $success = $reaction->save($this->user, $this->comment);
+            if ($success) {
+                $this->ms->success("<0>Reaction added");
+                $action = "added";
+            } else {
+                return JsonResult::make_error(500, "<0>Failed to add reaction");
+            }
+        }
+
+        $jr = new JsonResult(200, ["ok" => true, "action" => $action]);
+        $jr["reactions"] = $this->comment->unparse_reactions($this->user);
+        if ($this->ms->has_message()) {
+            $jr["message_list"] = $this->ms->message_list();
+        }
+        
+        return $jr;
+    }
+
+    /** @return JsonResult */
+    private function handle_get() {
+        $jr = new JsonResult(200, ["ok" => true]);
+        $jr["reactions"] = $this->comment->unparse_reactions($this->user);
+        return $jr;
+    }
+
+    static function run(Contact $user, Qrequest $qreq, PaperInfo $prow) {
+        // Get comment ID
+        $comment_id = $qreq->c ?? $qreq->comment_id ?? null;
+        if (!$comment_id || !ctype_digit($comment_id)) {
+            return JsonResult::make_parameter_error("c");
+        }
+
+        // Fetch comment
+        $comments = $prow->fetch_comments("commentId=" . (int) $comment_id);
+        if (empty($comments)) {
+            return JsonResult::make_error(404, "<0>Comment not found");
+        }
+
+        $comment = $comments[0];
+        return (new Reaction_API($user, $prow, $comment))->run_qreq($qreq);
+    }
+}

--- a/src/api/api_reaction.php
+++ b/src/api/api_reaction.php
@@ -25,7 +25,7 @@ class Reaction_API {
     /** @return JsonResult */
     private function run_qreq(Qrequest $qreq) {
         // Check if reactions are enabled
-        if (!$this->conf->setting("cmt_reactions", 1)) {
+        if ($this->conf->setting("cmt_reactions") <= 0) {
             return JsonResult::make_error(404, "<0>Comment reactions are disabled");
         }
 

--- a/src/commentinfo.php
+++ b/src/commentinfo.php
@@ -735,7 +735,7 @@ class CommentInfo {
      * @return string */
     function unparse_reactions_html(Contact $viewer) {
         // Check if reactions are enabled
-        if (!$this->conf->setting("cmt_reactions", 1)) {
+        if (($this->conf->setting("cmt_reactions") ?? 1) <= 0) {
             return "";
         }
 
@@ -968,9 +968,16 @@ class CommentInfo {
         }
 
         // reactions
-        if ($this->commentId > 0 && $viewer->can_view_comment($this->prow, $this, true)) {
+        if ($this->commentId > 0
+            && ($this->conf->setting("cmt_reactions") ?? 1) > 0
+            && $viewer->can_view_comment($this->prow, $this, true)) {
             $reactions = $this->unparse_reactions($viewer);
-            $cj["reactions"] = $reactions;
+            if (!empty($reactions)) {
+                $cj["reactions"] = $reactions;
+            }
+            if ($viewer->can_view_comment($this->prow, $this)) {
+                $cj["can_react"] = true;
+            }
         }
 
         return (object) $cj;

--- a/src/commentreaction.php
+++ b/src/commentreaction.php
@@ -1,0 +1,196 @@
+<?php
+// commentreaction.php -- HotCRP helper class for comment reactions
+// Copyright (c) 2008-2025 Eddie Kohler; see LICENSE.
+
+class CommentReaction {
+    /** @var Conf
+     * @readonly */
+    public $conf;
+    /** @var int */
+    public $reactionId = 0;
+    /** @var int */
+    public $commentId = 0;
+    /** @var int */
+    public $contactId = 0;
+    /** @var string */
+    public $emoji = "";
+    /** @var int */
+    public $timeModified = 0;
+    
+    /** @var ?Contact */
+    private $_user;
+
+    function __construct(?Conf $conf = null) {
+        $this->conf = $conf;
+    }
+
+    /** @suppress PhanAccessReadOnlyProperty */
+    private function _incorporate(Conf $conf) {
+        $this->conf = $conf;
+        $this->reactionId = (int) $this->reactionId;
+        $this->commentId = (int) $this->commentId;
+        $this->contactId = (int) $this->contactId;
+        $this->timeModified = (int) $this->timeModified;
+    }
+
+    /** @param Dbl_Result $result
+     * @return ?CommentReaction */
+    static function fetch($result, Conf $conf) {
+        $reaction = $result->fetch_object("CommentReaction");
+        if ($reaction) {
+            $reaction->_incorporate($conf);
+        }
+        return $reaction;
+    }
+
+    /** @return Contact */
+    function user() {
+        if ($this->_user === null) {
+            $this->_user = $this->conf->user_by_id($this->contactId, USER_SLICE)
+                ?? Contact::make_deleted($this->conf, $this->contactId);
+        }
+        return $this->_user;
+    }
+
+    /** @return string */
+    function emoji_unicode() {
+        static $emoji_map = null;
+        if ($emoji_map === null) {
+            $emoji_file = SiteLoader::find("scripts/emojicodes.json");
+            if ($emoji_file) {
+                $emoji_data = json_decode(file_get_contents($emoji_file), true);
+                $emoji_map = $emoji_data["emoji"] ?? [];
+            } else {
+                $emoji_map = [];
+            }
+        }
+        return $emoji_map[$this->emoji] ?? $this->emoji;
+    }
+
+    /** @param Conf $conf
+     * @return list<string> */
+    static function default_reaction_emojis(Conf $conf) {
+        $custom_list = $conf->opt("commentReactionEmojis");
+        if (is_string($custom_list)) {
+            return array_map('trim', explode(',', $custom_list));
+        }
+        return ["thumbs_up", "thumbs_down", "heart", "laugh", "confused", "hooray", "rocket", "eyes"];
+    }
+
+    /** @param Contact $viewer
+     * @param PaperInfo $prow
+     * @param CommentInfo $comment
+     * @return bool */
+    function can_view_identity(Contact $viewer, PaperInfo $prow, CommentInfo $comment) {
+        // Follow the same visibility rules as comment identity
+        // We need to check if viewer can see the reactor's identity in context of this comment
+        $reactor = $this->user();
+        
+        // If viewer can see comment identity in general, they can see reactor identity
+        if ($viewer->can_view_comment_identity($prow, $comment)) {
+            return true;
+        }
+        
+        // If reactor is the same as comment author and viewer can see comment author identity
+        if ($reactor->contactId === $comment->contactId 
+            && $viewer->can_view_comment_identity($prow, $comment)) {
+            return true;
+        }
+        
+        // Follow same rules as comment pseudonyms
+        return false;
+    }
+
+    /** @param Contact $viewer
+     * @param PaperInfo $prow
+     * @param CommentInfo $comment
+     * @return string */
+    function unparse_user_html(Contact $viewer, PaperInfo $prow, CommentInfo $comment) {
+        if ($this->can_view_identity($viewer, $prow, $comment)) {
+            return Text::nameo_h($this->user(), NAME_P);
+        } else {
+            // Use same pseudonym logic as comments
+            if (($comment->commentType & CommentInfo::CTM_BYAUTHOR) !== 0) {
+                return "Author";
+            } else if (($rrow = $prow->review_by_user($this->contactId))
+                       && $rrow->reviewOrdinal
+                       && $viewer->can_view_review_assignment($prow, $rrow)) {
+                return "Reviewer " . unparse_latin_ordinal($rrow->reviewOrdinal);
+            } else {
+                return "Anonymous";
+            }
+        }
+    }
+
+    /** @param Contact $acting_user
+     * @param CommentInfo $comment
+     * @return bool */
+    function save(Contact $acting_user, CommentInfo $comment) {
+        if (!$this->emoji || !$this->commentId || !$this->contactId) {
+            return false;
+        }
+
+        $this->timeModified = Conf::$now;
+        
+        if ($this->reactionId > 0) {
+            // Update existing reaction
+            $result = $this->conf->qe("UPDATE CommentReaction SET emoji=?, timeModified=? WHERE reactionId=?",
+                $this->emoji, $this->timeModified, $this->reactionId);
+        } else {
+            // Insert new reaction - check for duplicate first
+            $existing = $this->conf->fetch_first_object(
+                "SELECT reactionId FROM CommentReaction WHERE commentId=? AND contactId=? AND emoji=?",
+                $this->commentId, $this->contactId, $this->emoji);
+            
+            if ($existing) {
+                // Already exists, just update timestamp
+                $this->reactionId = (int) $existing->reactionId;
+                $result = $this->conf->qe("UPDATE CommentReaction SET timeModified=? WHERE reactionId=?",
+                    $this->timeModified, $this->reactionId);
+            } else {
+                // Insert new
+                $result = $this->conf->qe("INSERT INTO CommentReaction (commentId, contactId, emoji, timeModified) VALUES (?, ?, ?, ?)",
+                    $this->commentId, $this->contactId, $this->emoji, $this->timeModified);
+                if ($result && $result->insert_id) {
+                    $this->reactionId = $result->insert_id;
+                }
+            }
+        }
+
+        if ($result && !Dbl::is_error($result)) {
+            $acting_user->log_activity_for($this->contactId, "Comment {$this->commentId}: added reaction :{$this->emoji}:", $comment->paperId);
+            return true;
+        }
+        return false;
+    }
+
+    /** @param Contact $acting_user
+     * @param CommentInfo $comment
+     * @return bool */
+    function delete(Contact $acting_user, CommentInfo $comment) {
+        if (!$this->reactionId) {
+            return false;
+        }
+
+        $result = $this->conf->qe("DELETE FROM CommentReaction WHERE reactionId=?", $this->reactionId);
+        if ($result && !Dbl::is_error($result)) {
+            $acting_user->log_activity_for($this->contactId, "Comment {$this->commentId}: removed reaction :{$this->emoji}:", $comment->paperId);
+            $this->reactionId = 0;
+            return true;
+        }
+        return false;
+    }
+
+    /** @param int $commentId
+     * @param Conf $conf
+     * @return list<CommentReaction> */
+    static function fetch_by_comment($commentId, Conf $conf) {
+        $reactions = [];
+        $result = $conf->qe("SELECT * FROM CommentReaction WHERE commentId=? ORDER BY emoji, timeModified", $commentId);
+        while (($reaction = self::fetch($result, $conf))) {
+            $reactions[] = $reaction;
+        }
+        Dbl::free($result);
+        return $reactions;
+    }
+}

--- a/src/commentreaction.php
+++ b/src/commentreaction.php
@@ -70,11 +70,22 @@ class CommentReaction {
     /** @param Conf $conf
      * @return list<string> */
     static function default_reaction_emojis(Conf $conf) {
+        $defaults = ["thumbsup", "thumbsdown", "heart", "joy", "confused", "tada", "rocket", "eyes"];
         $custom_list = $conf->opt("commentReactionEmojis");
-        if (is_string($custom_list)) {
-            return array_map('trim', explode(',', $custom_list));
+        if ($custom_list !== null) {
+            if (is_string($custom_list)) {
+                $custom_list = array_map('trim', explode(',', $custom_list));
+            }
+            if (is_array($custom_list)) {
+                $custom_list = array_values(array_filter($custom_list, function ($e) {
+                    return $e !== '';
+                }));
+                if (!empty($custom_list)) {
+                    return $custom_list;
+                }
+            }
         }
-        return ["thumbs_up", "thumbs_down", "heart", "laugh", "confused", "hooray", "rocket", "eyes"];
+        return $defaults;
     }
 
     /** @param Contact $viewer

--- a/src/conference.php
+++ b/src/conference.php
@@ -367,7 +367,7 @@ class Conf {
 
     function load_settings() {
         $this->__load_settings();
-        if ($this->sversion < 312) {
+        if ($this->sversion < 313) {
             $old_nerrors = Dbl::$nerrors;
             while ((new UpdateSchema($this))->run()) {
                 usleep(50000);

--- a/src/papertable.php
+++ b/src/papertable.php
@@ -2995,6 +2995,10 @@ class PaperTable {
             }
         }
 
+        $s .= "hotcrp.set_reaction_emojis(" . $this->conf->setting("comment_reactions", false) . ");\n";
+        if ($this->conf->setting("cmt_reactions", false)) {
+            $s .= "hotcrp.set_reaction_emojis(" . json_encode_browser($this->conf->setting("opt.commentReactionEmojis", [])) . ");\n";
+        }
         if ($ncmt) {
             CommentInfo::print_script($this->prow);
         }

--- a/src/papertable.php
+++ b/src/papertable.php
@@ -2954,6 +2954,12 @@ class PaperTable {
         }
 
         $s = "";
+        $reactions_enabled = $this->conf->setting("cmt_reactions");
+        $quick_emojis = $reactions_enabled ? CommentReaction::default_reaction_emojis($this->conf) : [];
+        $s .= "hotcrp.set_reaction_config("
+            . json_encode_browser(["enabled" => $reactions_enabled, "quick" => $quick_emojis])
+            . ");\n";
+
         $ncmt = 0;
         $pex = new PaperExport($this->user);
         foreach ($rcs as $rc) {
@@ -2995,10 +3001,6 @@ class PaperTable {
             }
         }
 
-        $s .= "hotcrp.set_reaction_emojis(" . $this->conf->setting("comment_reactions", false) . ");\n";
-        if ($this->conf->setting("cmt_reactions", false)) {
-            $s .= "hotcrp.set_reaction_emojis(" . json_encode_browser($this->conf->setting("opt.commentReactionEmojis", [])) . ");\n";
-        }
         if ($ncmt) {
             CommentInfo::print_script($this->prow);
         }

--- a/src/updateschema.php
+++ b/src/updateschema.php
@@ -3179,6 +3179,17 @@ set ordinal=(t.maxOrdinal+1) where commentId={$row[1]}");
             && $conf->ql_ok("alter table MailLog change `q` `q` varbinary(16384) DEFAULT NULL")) {
             $conf->update_schema_version(312);
         }
+        if ($conf->sversion === 312
+            && $conf->ql_ok("CREATE TABLE `CommentReaction` (
+`reactionId` int(11) NOT NULL AUTO_INCREMENT,
+`commentId` int(11) NOT NULL,
+`contactId` int(11) NOT NULL,
+`emoji` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+`timeModified` bigint(11) NOT NULL,
+PRIMARY KEY (`reactionId`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4")) {
+            $conf->update_schema_version(313);
+        }
 
         $conf->ql_ok("delete from Settings where name='__schema_lock'");
         Conf::$main = $old_conf_g;

--- a/src/updateschema.php
+++ b/src/updateschema.php
@@ -3187,7 +3187,8 @@ set ordinal=(t.maxOrdinal+1) where commentId={$row[1]}");
 `emoji` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
 `timeModified` bigint(11) NOT NULL,
 PRIMARY KEY (`reactionId`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4")) {
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4")
+            && $conf->save_setting("cmt_reactions", 1)) {
             $conf->update_schema_version(313);
         }
 

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -4596,7 +4596,7 @@ a:hover .t-editor,
 	background: #f8f8f6;
 	position: relative;
 	padding-top: 1.25rem;
-	padding-bottom: 2.25rem;
+	padding-bottom: 1.25rem;
 }
 .cmtcard.comment:last-child {
 	border-bottom: 5px solid #e6e1cf;
@@ -4819,6 +4819,122 @@ a:hover .cmtnum,
 .cmtcard.edit.popout .cmttext {
 	max-height: 50vh;
 }
+}
+
+/* reactions */
+
+.comment-reactions {
+    margin-top: 6px;
+	margin-bottom: 2px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: start;
+}
+
+.reaction-item {
+    display: inline-flex;
+    align-items: center;
+    background: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 12px;
+    padding: 2px 6px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+	margin-bottom: 10px; /* if a reaction is present, add extra space */
+}
+
+.reaction-item:hover {
+    background: #e9ecef;
+    border-color: #adb5bd;
+}
+
+.reaction-item.viewer-reacted {
+    background: #e3f2fd;
+    border-color: #2196f3;
+    color: #1976d2;
+}
+
+.reaction-item .emoji-unicode {
+    margin-right: 2px;
+}
+
+.reaction-item .reaction-count {
+    font-weight: 500;
+	margin-left: 2px;
+}
+
+.reaction-picker-btn {
+    background: #ecece8;
+    border: 1px solid #bcc5cd;
+    border-radius: 12px;
+    padding: 2px 12px;
+    font-size: 12px;
+    cursor: pointer;
+    opacity: 0.7;
+	visibility: hidden;
+}
+
+.reaction-picker-btn:hover {
+    opacity: 1;
+    border-color: #adb5bd;
+}
+
+.cmtcard:hover .reaction-picker-btn {
+	visibility: visible;
+}
+
+.emoji-picker {
+    position: fixed;
+    background: var(--paper);
+    border: 1px solid #dee2e6;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    padding: 4px;
+    width: 240px;
+    max-height: 300px;
+    overflow-y: auto;
+    z-index: 1000;
+}
+
+.emoji-grid {
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    gap: 2px;
+}
+
+.emoji-option, .open-emoji-search {
+    background: none;
+    border: none;
+    padding: 3px 1px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: background-color 0.1s ease;
+}
+
+.emoji-option:hover {
+    background: #e0e1e1;
+}
+
+.emoji-search {
+    width: 100%;
+    padding: 6px 8px;
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+    font-size: 12px;
+	margin-top: 3px;
+}
+
+.emoji-search:focus {
+    outline: none;
+    border-color: #2196f3;
+}
+
+.emoji-all {
+    max-height: 150px;
+    overflow-y: auto;
 }
 
 a.tagbg, span.tagbg {

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -4869,8 +4869,8 @@ a:hover .cmtnum,
     background: #ecece8;
     border: 1px solid #bcc5cd;
     border-radius: 12px;
-    padding: 2px 12px;
-    font-size: 12px;
+    padding: 2px 8px;
+    font-size: 0;
     cursor: pointer;
     opacity: 0.7;
 	visibility: hidden;


### PR DESCRIPTION
This pull request adds the ability to add emoji reactions to comments, similar to functionality in social networks and messaging apps. When hovering over a comment, a button labelled + appears
<img width="479" height="123" alt="image" src="https://github.com/user-attachments/assets/a71de1e0-3ac5-4046-9be4-6aa0b8439b42" />
Clicking the button opens a hovering panel showing a number of standard reaction emojis as well as ellipses "..." allowing users to choose from the full set of emojis.
<img width="319" height="123" alt="image" src="https://github.com/user-attachments/assets/56df4e07-cd73-4aa0-8005-3689de5a5a62" />
Once a reaction is added, it is displayed below the comment and can be seen by everyone who can see the comment. On hover, the identity of the reacters is shown. The same person can add multiple reactions.
<img width="226" height="67" alt="image" src="https://github.com/user-attachments/assets/9ca3088f-e4e4-41dd-87a5-a17311b54dde" />
The icon is blue if the currently logged-in user has reacted that way, and on clicking it, the reaction is removed.

Reactions are logged in the action log:
<img width="1009" height="65" alt="image" src="https://github.com/user-attachments/assets/820f80b0-7f01-4ae7-a2e8-30afe4e0091f" />

There are settings for turning reactions on or off in the admin JSON settings, as well as to configure the list of standard emojis displayed:
<img width="1185" height="423" alt="image" src="https://github.com/user-attachments/assets/95eadaa7-adf8-4e66-a874-2da38bf6d330" />



