### PR TITLE
Fix Present dropdown always rendering as custom search input

### DIFF
--- a/src/settings/s_subfieldcondition.php
+++ b/src/settings/s_subfieldcondition.php
@@ -15,7 +15,7 @@ class SubFieldCondition_SettingParser extends SettingParser {
         if ($pres === "none" || $osp->sfs->option_id <= 0) {
             $sel["none"] = "Disabled";
         }
-        if (!isset($pressel[$pres])) {
+        if (!isset($sel[$pres])) {
             $sv->print_control_group("sf/{$osp->ctr}/condition", "Present", "Custom search", [
                 "horizontal" => true
             ]);


### PR DESCRIPTION
The condition `!isset($sel[$pres])` was always true because `$pressel` was undefined. This caused the 'Present' submission field to render as a custom search input instead of the select dropdown.

Replace `$pressel` with the correctly defined `$sel` containing the dropdown options (Yes, Disabled, In final-version phase).

Buggy:
<img width="828" height="294" alt="image" src="https://github.com/user-attachments/assets/2df18d2e-cfb6-4c9b-9f1a-3f0b51329442" />

After Fix:
<img width="827" height="302" alt="image" src="https://github.com/user-attachments/assets/c728a1cf-4399-499b-877c-a9a96330de44" />
