### PR TITLE
Allow % for grant host option in createdb.sh

### DIFF
--- a/lib/createdb.sh
+++ b/lib/createdb.sh
@@ -50,7 +50,7 @@ set_dbuserpass () {
 }
 
 add_granthost () {
-    if expr "$1" : '[-a-zA-Z0-9.*][-a-zA-Z0-9.*]*$' >/dev/null; then
+    if expr "x$1" : 'x[-a-zA-Z0-9.*%_][-a-zA-Z0-9.*%_]*$' >/dev/null; then
         granthosts="$granthosts $1"
     else
         echo "Expected --grant-host=HOSTNAME" 1>&2


### PR DESCRIPTION
This change allow "%" to be set on the host for database grant. There are a few use cases when runnig tests:
1. Allow the test database to be on a differnet host
2. A container can be used on the same host to provide test database.