### PR TITLE
Document tagging of comments

### DIFF
--- a/src/help/h_keywords.php
+++ b/src/help/h_keywords.php
@@ -168,6 +168,7 @@ class Keywords_HelpTopic {
         echo $hth->search_trow("cmt:>=3", "at least <em>three</em> visible reviewer comments");
         echo $hth->search_trow("has:aucmt", "at least one reviewer comment visible to authors");
         echo $hth->search_trow("cmt:sylvia", "“sylvia” (in name/email) wrote at least one visible comment; can combine with counts, use reviewer tags");
+        echo $hth->search_trow("cmt:#foo", "at least one visible reviewer comment has tag #foo");
         $rrds = $hth->conf->response_round_list();
         if (count($rrds) > 1) {
             echo $hth->search_trow("has:response", "has an author’s response");

--- a/src/help/h_tags.php
+++ b/src/help/h_tags.php
@@ -59,6 +59,10 @@ case insensitive, so “#TAG” and “#tAg” are considered identical.</p>";
 paper’s tags, or “", $hth->search_link("show:#tagname"), "” to see a particular tag
 as a column.</p>
 
+<p>Comments can also be tagged. While writing a comment, use the comment editor’s
+tag entry to add tags such as “#foo”. To search for papers with comments tagged
+“#foo”, search for “", $hth->search_link("cmt:#foo"), "”.</p>
+
 <p>Tags are only shown to PC members and administrators. ";
         if ($this->user->isPC) {
             if ($this->conf->pc_can_view_conflicted_tags()) {


### PR DESCRIPTION
I didn't find anywhere currently in the help docs indicating that comments can have tags separate from paper tags, so I added a bit of documentation, including how to search.