### PR TITLE
Normalize sendmail additional_params to string for PHP 8

### DIFF
--- a/lib/mailpreparation.php
+++ b/lib/mailpreparation.php
@@ -307,6 +307,7 @@ class MailPreparation implements JsonSerializable {
             }
             unset($headers["subject"]);
             $htext = substr(join("", $headers), 0, -2);
+            $extra = $extra ?? '';
             return ($this->sent = mail($to, $this->subject, $qpe_body, $htext, $extra));
         }
 


### PR DESCRIPTION
Avoid passing null to mail() additional_params argument, which triggers PHP 8 deprecation warnings.