### PR TITLE
Fix color scheme for procrastination graph in dark mode

### DIFF
--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -5850,18 +5850,18 @@ th.pl_logaction {
 /* graphs */
 .gcdf {
 	fill: none;
-	stroke: rgba(0, 92, 168, 0.5);
+	stroke: light-dark(rgba(0, 92, 168, 0.5), gray);
 	stroke-width: 1.5px;
 }
 .gcdf-many {
-	stroke: rgba(70, 130, 180, 0.5);
+	stroke: light-dark(rgba(70, 130, 180, 0.5), gray);
 }
 .gcdf-cumulative {
 	stroke: red;
 	stroke-width: 2.5px;
 }
 .gcdf-highlight {
-	stroke: black;
+	stroke: light-dark(black, aqua);
 }
 .gcdf-thin {
 	stroke-width: 0.5px;


### PR DESCRIPTION
I absolutely love the support for dark mode/theme for hotcrp.
However, it sort of broke my favorite feature of hotcrp: the procrastination graph. The following is what dark mode procrastination graph looks like from an existing hotcrp website:

<img width="973" height="518" alt="Screenshot from 2026-08-15 14-17-13" src="https://github.com/user-attachments/assets/9cc20ffe-3ef4-42bd-a8c8-693ed1ee9c95" />

With this new color scheme, this is what the procrastination graph looks like now (tested by changing the style sheet in the inspect element tab on Firefox)

<img width="969" height="498" alt="image" src="https://github.com/user-attachments/assets/f9ad85b7-f846-45d1-8901-d27306d93c59" />
